### PR TITLE
Fixed make test-sim-nondeterminism.

### DIFF
--- a/incubator/nft/genesis.go
+++ b/incubator/nft/genesis.go
@@ -9,7 +9,8 @@ func InitGenesis(ctx sdk.Context, k Keeper, data GenesisState) {
 	k.SetOwners(ctx, data.Owners)
 
 	for _, c := range data.Collections {
-		k.SetCollection(ctx, c.Denom, c)
+		sortedCollection := NewCollection(c.Denom, c.NFTs.Sort())
+		k.SetCollection(ctx, c.Denom, sortedCollection)
 	}
 }
 

--- a/incubator/nft/simulation/operations.go
+++ b/incubator/nft/simulation/operations.go
@@ -109,6 +109,7 @@ func SimulateMsgTransferNFT(ak types.AccountKeeper, k keeper.Keeper) simulation.
 		}
 
 		ownerAcc, ok := simulation.FindAccount(accs, ownerAddr)
+		ownerAuthAcc := ak.GetAccount(ctx, ownerAddr)
 		if !ok {
 			return simulation.NoOpMsg(types.ModuleName), nil, errors.New("could not find acc")
 		}
@@ -118,8 +119,8 @@ func SimulateMsgTransferNFT(ak types.AccountKeeper, k keeper.Keeper) simulation.
 			fees,
 			helpers.DefaultGenTxGas,
 			chainID,
-			[]uint64{acc.GetAccountNumber()},
-			[]uint64{acc.GetSequence()},
+			[]uint64{ownerAuthAcc.GetAccountNumber()},
+			[]uint64{ownerAuthAcc.GetSequence()},
 			ownerAcc.PrivKey,
 		)
 


### PR DESCRIPTION
Possibly fixes this issue, please check: https://github.com/cosmos/modules/issues/29

Wrong Sequence and AccountNumber were used. Also, NFT collections were assumed to be sorted, but in fact it is possible to create an unsorted collection through the genesis, so the binary search did not work.

The trick with this bug is that the JSON serialization sorts collections, so everything looked fine in the log.